### PR TITLE
:ambulance: HOTFIX : 인기 검색어 검색 결과 캐싱 데이터가 어떤 페이지를 조회해도 같은 결과가 나오는 현상을…

### DIFF
--- a/src/main/kotlin/com/team4/moviereview/domain/movie/controller/MovieController.kt
+++ b/src/main/kotlin/com/team4/moviereview/domain/movie/controller/MovieController.kt
@@ -43,7 +43,7 @@ class MovieController(
     }
 
     @StopWatch
-    @GetMapping("/search/v2")
+    @GetMapping("/v2/search")
     fun searchMoviesWithCache(
         @RequestParam(value = "keyword", required = true) keyword: String,
         pageable: Pageable,
@@ -67,21 +67,23 @@ class MovieController(
     @StopWatch
     @GetMapping("/v1/category")
     fun getMoviesByCategory(
-        @RequestParam(value = "categoryName") categoryName: String
+        @RequestParam(value = "categoryName") categoryName: String,
+        pageable: Pageable,
     ): ResponseEntity<List<MovieResponse>> {
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(movieService.getMoviesByCategory(categoryName))
+            .body(movieService.getMoviesByCategory(categoryName, pageable))
     }
 
     @StopWatch
     @GetMapping("/v2/category")
     fun getMoviesByCategoryWithCache(
         @RequestParam(value = "categoryName") categoryName: String,
+        pageable: Pageable,
     ): ResponseEntity<List<MovieResponse>> {
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(movieService.getMoviesByCategoryWithCache(categoryName))
+            .body(movieService.getMoviesByCategoryWithCache(categoryName, pageable))
     }
 
 }

--- a/src/main/kotlin/com/team4/moviereview/domain/movie/repository/movieRepository/CustomMovieRepository.kt
+++ b/src/main/kotlin/com/team4/moviereview/domain/movie/repository/movieRepository/CustomMovieRepository.kt
@@ -18,6 +18,6 @@ interface CustomMovieRepository {
 
     fun filterMovies(request: FilterRequest, pageable: Pageable): List<MovieData>
 
-    fun getMoviesByCategory(categoryName: String): List<MovieData>
+    fun getMoviesByCategory(categoryName: String, pageable: Pageable): List<MovieData>
 
 }

--- a/src/main/kotlin/com/team4/moviereview/domain/movie/repository/movieRepository/MovieRepositoryImpl.kt
+++ b/src/main/kotlin/com/team4/moviereview/domain/movie/repository/movieRepository/MovieRepositoryImpl.kt
@@ -169,7 +169,7 @@ class MovieRepositoryImpl : CustomMovieRepository, QueryDslSupport() {
         return movies
     }
 
-    override fun getMoviesByCategory(categoryName: String): List<MovieData> {
+    override fun getMoviesByCategory(categoryName: String, pageable: Pageable): List<MovieData> {
 
         // TODO : 추후에 동적으로 정렬기준이 생길수도
         // TODO : 추후에 페이지네이션으로 바꿀수도
@@ -193,6 +193,8 @@ class MovieRepositoryImpl : CustomMovieRepository, QueryDslSupport() {
                 movie.id
             )
             .orderBy(movie.releaseDate.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
             .fetch()
 
 

--- a/src/main/kotlin/com/team4/moviereview/domain/movie/service/MovieService.kt
+++ b/src/main/kotlin/com/team4/moviereview/domain/movie/service/MovieService.kt
@@ -14,9 +14,9 @@ interface MovieService {
 
     fun filterMovies(request: FilterRequest, pageable: Pageable): List<MovieResponse>
 
-    fun getMoviesByCategory(categoryName: String): List<MovieResponse>
+    fun getMoviesByCategory(categoryName: String, pageable: Pageable): List<MovieResponse>
 
-    fun getMoviesByCategoryWithCache(categoryName: String): List<MovieResponse>
+    fun getMoviesByCategoryWithCache(categoryName: String, pageable: Pageable): List<MovieResponse>
 
     fun evictMovieListCache()
 }

--- a/src/main/kotlin/com/team4/moviereview/domain/search/service/SearchService.kt
+++ b/src/main/kotlin/com/team4/moviereview/domain/search/service/SearchService.kt
@@ -76,7 +76,6 @@ class SearchService(
             val searchWords = cachedWords.map { SearchWord(it.value, LocalDate.now()) }
             searchWordRepository.saveAll(searchWords)
         }
-
         cache?.evict("keywordCache")
     }
 
@@ -102,6 +101,5 @@ class SearchService(
         }
         cache?.evict("hotCategory")
     }
-
 
 }


### PR DESCRIPTION
… 고쳣습니다

- 이제 인기 검색어로 검색한 결과의 첫번째 페이지만 캐싱되고 나머지는 db에서 조회됩니다
- 해당 메서드를 실행하는 컨트롤러의 uri를 정책에 맞게 수정했습니다
- 같은 로직을 페이지네이션이 안되있던 getMovieByCategoryWithCache 에도 적용시켰습니다